### PR TITLE
新增TTL参数支持

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ENV CGO_ENABLED=0 \
 RUN apk add --update git curl
 ADD . $GOPATH/src/github.com/honwen/aliyun-ddns-cli
 RUN set -ex \
+    && go env -w GOPROXY=https://goproxy.cn \
     && cd $GOPATH/src/github.com/honwen/aliyun-ddns-cli \
     && go build -ldflags "-X main.VersionString=$(curl -sSL https://api.github.com/repos/honwen/aliyun-ddns-cli/commits/master | \
             sed -n '{/sha/p; /date/p;}' | sed 's/.* \"//g' | cut -c1-10 | tr '[:lower:]' '[:upper:]' | sed 'N;s/\n/@/g' | head -1)" . \
@@ -20,11 +21,13 @@ ENV AKID=1234567890 \
     AKSCT=abcdefghijklmn \
     DOMAIN=ddns.example.win \
     IPAPI=[IPAPI-GROUP] \
-    REDO=0
+    REDO=0 \
+    TTL=600
 
 CMD aliyun-ddns-cli \
     --ipapi ${IPAPI} \
     ${IPV6:+-6} \
     auto-update \
     --domain ${DOMAIN} \
-    --redo ${REDO}
+    --redo ${REDO} \
+    --ttl ${TTL}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ $ docker run -d \
     -e "AKSCT=[ALIYUN's AccessKey-Secret]" \
     -e "DOMAIN=ddns.aliyun.win" \
     -e "REDO=600" \
+    -e "TTL=600" \
     chenhw2/aliyun-ddns-cli
 ```
 

--- a/alidns/AddDomainRecord.go
+++ b/alidns/AddDomainRecord.go
@@ -13,6 +13,7 @@ type AddDomainRecordArgs struct {
 	Value      string
 
 	//optional
+	TTL  string
 	Line string
 }
 

--- a/alidns/AddDomainRecord_test.go
+++ b/alidns/AddDomainRecord_test.go
@@ -11,6 +11,7 @@ func TestAddDomainRecord(t *testing.T) {
 		RR:         "testaddrecord",
 		Type:       ARecord,
 		Value:      "8.8.8.8",
+		TTL:        "600"
 	}
 	response, err := client.AddDomainRecord(&addDomainRecordArgs)
 	if err == nil {

--- a/alidns/DeleteDomainRecord_test.go
+++ b/alidns/DeleteDomainRecord_test.go
@@ -12,6 +12,7 @@ func TestDeleteDomainRecord(t *testing.T) {
 		RR:         "testdeleterecordid",
 		Type:       ARecord,
 		Value:      "8.8.8.8",
+		TTL:        "600",
 	}
 
 	addResponse, err := client.AddDomainRecord(&addDomainRecordArgs)

--- a/alidns/DeleteSubDomainRecords_test.go
+++ b/alidns/DeleteSubDomainRecords_test.go
@@ -12,6 +12,7 @@ func TestDeleteSubDomainRecords(t *testing.T) {
 		RR:         "testdeletesubdomainrecords",
 		Type:       ARecord,
 		Value:      "8.8.8.8",
+		TTL:        "600",
 	}
 
 	client.AddDomainRecord(&addDomainRecordArgs)

--- a/alidns/UpdateDomainRecord.go
+++ b/alidns/UpdateDomainRecord.go
@@ -9,7 +9,7 @@ type UpdateDomainRecordArgs struct {
 	Value    string
 
 	//optional
-	TTL      int32
+	TTL      string
 	Priority int32
 	Line     string
 }

--- a/alidns/UpdateDomainRecord_test.go
+++ b/alidns/UpdateDomainRecord_test.go
@@ -12,6 +12,7 @@ func TestUpdateDomainRecord(t *testing.T) {
 		RR:         "testupdaterecordid",
 		Value:      "8.8.8.8",
 		Type:       ARecord,
+		TTL:        "600",
 	}
 
 	addResponse, err := client.AddDomainRecord(&addDomainRecordArgs)
@@ -22,6 +23,7 @@ func TestUpdateDomainRecord(t *testing.T) {
 		RR:       addDomainRecordArgs.RR,
 		Value:    "4.4.4.4",
 		Type:     ARecord,
+		TTL:      "600",
 	}
 
 	_, err = client.UpdateDomainRecord(&updateArgs)


### PR DESCRIPTION
我已经测试，验证的容器地址是  xzxiaoshan/aliyun-ddns-cli:ttl ，增加了 TTL 参数。
请求合并。
--------------------
I have tested that the verified container address is xzxiaoshan/aliyun-ddns-cli:ttl, and the TTL parameter is added.
Request merge.